### PR TITLE
Integrate GitVersion with Gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Install GitVersion
+        run: dotnet tool install --global GitVersion.Tool
+
+      - name: Determine version using GitVersion
+        run: gitversion /output json /showvariable FullSemVer
+        id: gitversion
+
       - name: Build with Gradle
-        run: ./gradlew :lib:assemble
+        run: ./gradlew :lib:assemble -Pversion=${{ steps.gitversion.outputs.FullSemVer }}
 
       - name: Run tests
         run: ./gradlew :lib:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Install GitVersion
-        run: dotnet tool install --global GitVersion.Tool
+        run: choco install gitversion.portable --version=5.12.0 -y
 
       - name: Determine version using GitVersion
         run: gitversion /output json /showvariable FullSemVer

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,0 +1,27 @@
+next-version: 1.0.0
+branches:
+  develop:
+    regex: ^develop
+    mode: ContinuousDeployment
+    tag: alpha
+    increment: Minor
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 0
+    
+  release:
+    regex: ^release
+    tag: beta
+    increment: Minor
+    is-release-branch: false
+    is-mainline: false
+
+  main:
+    regex: ^main
+    mode: ContinuousDeployment
+    is-release-branch: true
+    is-mainline: true

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,6 +12,9 @@ plugins {
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
+
+    // Apply the GitVersion plugin
+    id("com.palantir.git-version") version "0.12.3"
 }
 
 repositories {
@@ -57,3 +60,11 @@ kotlin {
 //        languageVersion = JavaLanguageVersion.of(11)
 //    }
 //}
+
+// Use GitVersion for versioning
+val gitVersion: groovy.lang.Closure<String> by extra
+version = gitVersion()
+
+gitVersion {
+    // Customize GitVersion settings if needed
+}


### PR DESCRIPTION
Integrate GitVersion with Gradle.

* Apply the `com.palantir.git-version` plugin in `lib/build.gradle.kts`.
* Add a `version` property to use the GitVersion plugin's version in `lib/build.gradle.kts`.
* Add a `gitVersion` configuration block to customize GitVersion settings in `lib/build.gradle.kts`.
* Add steps to install and use GitVersion in the GitHub Actions workflow in `.github/workflows/ci.yml`.
* Add a `gitversion.yml` file with configurations for `develop`, `release`, and `main` branches.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/holance/ktbus/pull/2?shareId=19e88e21-df5a-466d-97d0-8bc4ee96321a).