### PR TITLE
Add GitVersion to GitHub Action and generate version automatically on build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,7 @@ jobs:
 
       - name: Determine Version
         id: version_step # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@v3.2.0
-        with:
-          useConfigFile: true
-          configFilePath: gitversion.yml
+        run:  /opt/hostedtoolcache/GitVersion.Tool/6.2.0/dotnet-gitversion /output json /l console /config gitversion.yml
 
       - name: Set version in Gradle build file
         run: ./gradlew -Pversion=$(version_step | jq -r '.SemVer')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,15 @@ jobs:
         run: chmod +x gradlew
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
+        uses: gittools/actions/gitversion/setup@v3.2.0
         with:
-          versionSpec: '5.x'
+          versionSpec: '6.2.x'
 
-      - name: Generate version information
-        id: gitversion
-        run: gitversion /output json /output buildserver
+      - name: Determine Version
+        id: gitversion # step id used as reference for output values
+        uses: gittools/actions/gitversion/execute@v3.2.0
+        with:
+          useConfigFile: true
 
       - name: Set version in Gradle build file
         run: ./gradlew -Pversion=$(gitversion | jq -r '.SemVer')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,9 @@ jobs:
         with:
           useConfigFile: true
           configFilePath: gitversion.yml
-      # - name: Determine Version
-      #   id: version_step # step id used as reference for output values
-      #   run:  |
-      #     /opt/hostedtoolcache/GitVersion.Tool/6.2.0/dotnet-gitversion /output json /l console /config gitversion.yml
-      #     echo "GitVersion.FullSemVer = $(GitVersion.FullSemVer)"
-      #     echo "GitVersion.SemVer = $(GitVersion.SemVer)"
 
       - name: Set version in Gradle build file
-        run: ./gradlew -Pversion=$(version_step | jq -r '.SemVer')
+        run: ./gradlew -Pversion=${{ steps.version_step.outputs.SemVer }}
 
       - name: Build with Gradle
         run: ./gradlew :lib:assemble
@@ -64,6 +58,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-$(version_step | jq -r '.SemVer')
+          name: build-artifacts-${{ steps.version_step.outputs.SemVer }}
           path: |
             lib/build/libs/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+
+      - name: Generate version information
+        id: gitversion
+        run: gitversion /output json /output buildserver
+
+      - name: Set version in Gradle build file
+        run: ./gradlew -Pversion=$(gitversion | jq -r '.SemVer')
+
       - name: Build with Gradle
         run: ./gradlew :lib:assemble
 
@@ -40,6 +52,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts
+          name: build-artifacts-$(gitversion | jq -r '.SemVer')
           path: |
             lib/build/libs/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,14 @@ jobs:
           versionSpec: '6.2.x'
 
       - name: Determine Version
-        id: gitversion # step id used as reference for output values
+        id: version_step # step id used as reference for output values
         uses: gittools/actions/gitversion/execute@v3.2.0
         with:
           useConfigFile: true
           configFilePath: gitversion.yml
 
       - name: Set version in Gradle build file
-        run: ./gradlew -Pversion=$(gitversion | jq -r '.SemVer')
+        run: ./gradlew -Pversion=$(version_step | jq -r '.SemVer')
 
       - name: Build with Gradle
         run: ./gradlew :lib:assemble
@@ -58,6 +58,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-$(gitversion | jq -r '.SemVer')
+          name: build-artifacts-$(version_step | jq -r '.SemVer')
           path: |
             lib/build/libs/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v3.2.0
         with:
           useConfigFile: true
+          configFilePath: gitversion.yml
 
       - name: Set version in Gradle build file
         run: ./gradlew -Pversion=$(gitversion | jq -r '.SemVer')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,19 @@ jobs:
         uses: gittools/actions/gitversion/setup@v3.2.0
         with:
           versionSpec: '6.2.x'
-
+          
       - name: Determine Version
         id: version_step # step id used as reference for output values
-        run:  /opt/hostedtoolcache/GitVersion.Tool/6.2.0/dotnet-gitversion /output json /l console /config gitversion.yml
+        uses: gittools/actions/gitversion/execute@v3.2.0
+        with:
+          useConfigFile: true
+          configFilePath: gitversion.yml
+      # - name: Determine Version
+      #   id: version_step # step id used as reference for output values
+      #   run:  |
+      #     /opt/hostedtoolcache/GitVersion.Tool/6.2.0/dotnet-gitversion /output json /l console /config gitversion.yml
+      #     echo "GitVersion.FullSemVer = $(GitVersion.FullSemVer)"
+      #     echo "GitVersion.SemVer = $(GitVersion.SemVer)"
 
       - name: Set version in Gradle build file
         run: ./gradlew -Pversion=$(version_step | jq -r '.SemVer')

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -17,10 +17,10 @@ branches:
     label: beta
     increment: Minor
     is-release-branch: false
-    is-mainline: false
+    is-main-branch: false
 
   main:
     regex: ^main
     mode: ContinuousDeployment
     is-release-branch: true
-    is-mainline: true
+    is-main-branch: true

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,4 +1,4 @@
-next-version: 0.1.0
+next-version: 1.0.0
 branches:
   develop:
     regex: ^develop

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -5,7 +5,6 @@ branches:
     mode: ContinuousDeployment
     label: alpha
     increment: Minor
-    prevent-increment-of-merged-branch-version: false
     track-merge-target: true
     source-branches: []
     tracks-release-branches: true

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,2 +1,27 @@
-mode: Mainline
-next-version: 1.0.0
+next-version: 0.1.0
+branches:
+  develop:
+    regex: ^develop
+    mode: ContinuousDeployment
+    tag: alpha
+    increment: Minor
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 0
+    
+  release:
+    regex: ^release
+    tag: beta
+    increment: Minor
+    is-release-branch: false
+    is-mainline: false
+
+  main:
+    regex: ^main
+    mode: ContinuousDeployment
+    is-release-branch: true
+    is-mainline: true

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -3,7 +3,7 @@ branches:
   develop:
     regex: ^develop
     mode: ContinuousDeployment
-    tag: alpha
+    label: alpha
     increment: Minor
     prevent-increment-of-merged-branch-version: false
     track-merge-target: true
@@ -15,7 +15,7 @@ branches:
     
   release:
     regex: ^release
-    tag: beta
+    label: beta
     increment: Minor
     is-release-branch: false
     is-mainline: false

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -9,7 +9,7 @@ branches:
     source-branches: []
     tracks-release-branches: true
     is-release-branch: false
-    is-mainline: false
+    is-main-branch: false
     pre-release-weight: 0
     
   release:

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,0 +1,2 @@
+mode: Mainline
+next-version: 1.0.0

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -51,6 +51,8 @@ kotlin {
     jvmToolchain(11) // Specify your target JVM version
 }
 
+version = System.getenv("VERSION") ?: "unspecified"
+
 // Apply a specific Java toolchain to ease working on different environments.
 //java {
 //    toolchain {


### PR DESCRIPTION
Add GitVersion to GitHub Actions workflow and generate version automatically on build artifacts.

* Modify `.github/workflows/ci.yml` to include steps for installing GitVersion, generating version information, setting the version in the Gradle build file, and uploading artifacts with version information in the name.
* Add `gitversion.yml` configuration file to set GitVersion to use the `Mainline` versioning mode and set the `next-version` to `1.0.0`.
* Modify `lib/build.gradle.kts` to set the version property using the environment variable `VERSION`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/holance/ktbus/pull/3?shareId=f99d957f-c1cf-4361-91fa-6c2f7f4a4f2e).